### PR TITLE
Fix checkout issues with this one easy trick.

### DIFF
--- a/binsync/client.py
+++ b/binsync/client.py
@@ -241,12 +241,24 @@ class Client(object):
 
         return repo
 
+    def ensure_checkout(self, print_error=False):
+        """
+        Ensure the repo is in the proper branch for current user.
+
+        :return: bool
+        """
+        name = self.user_branch_name
+        
+        self.repo.git.checkout(name)
+
     def pull(self, print_error=False):
         """
         Pull changes from the remote side.
 
         :return:    None
         """
+
+        self.ensure_checkout()
 
         self._last_pull_attempt_at = datetime.datetime.now()
 
@@ -271,6 +283,8 @@ class Client(object):
 
         :return:    None
         """
+
+        self.ensure_checkout()
 
         self._last_push_attempt_at = datetime.datetime.now()
 
@@ -437,6 +451,9 @@ class Client(object):
         self._last_commit_ts = time.time()
 
     def save_state(self, state=None):
+
+        # Ensure we are in the correct branch
+        self.ensure_checkout()
 
         if state is None:
             state = self.state


### PR DESCRIPTION
# Bug
When syncing the repos (pull, push, or save_state), if the branch in the checked out repo is not the same as the current user, syncing will go "out-of-sync" and start erroring out the current states of the user. 

# Remediation
Adding the following function to the client class then placing this in the beginning of Client.push(), Client.pull() and Client.save_state() will remediate this for now:

```python
    def ensure_checkout(self, print_error=False):
        """
        Ensure the repo is in the proper branch for current user.

        :return: bool
        """
        name = self.user_branch_name
        
        self.repo.git.checkout(name)

```

An alternative would be to make this as a decorator though at the moment I have not done that. 