### PR TITLE
fix double click in ida

### DIFF
--- a/plugins/ida_binsync/ida_binsync/ui/sync_menu.py
+++ b/plugins/ida_binsync/ida_binsync/ui/sync_menu.py
@@ -104,8 +104,14 @@ class MenuDialog(QDialog):
         # set more table properties
         table_widget.setSelectionBehavior(QAbstractItemView.SelectRows)
         table_widget.setSelectionMode(QAbstractItemView.SingleSelection)
-
+        table_widget.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table_widget.doubleClicked.connect(self._on_click)
+        
         return table_widget
+
+    def _on_click(self, index):
+        self.active_table.selectRow(index.row())
+        self.accept()
 
     def _build_menu_table_for_all_users(self):
         if self.controller.client.has_remote:


### PR DESCRIPTION
Fixed double clicking crashing on ida by adding a handler to it and marking the table as uneditable.