### PR TITLE
fix table sizing issues, add toggle support to panel

### DIFF
--- a/binsync/common/controller.py
+++ b/binsync/common/controller.py
@@ -213,6 +213,9 @@ class BinSyncController:
         else:
             return "<font color=#cc3232>Disconnected</font>"
 
+    def toggle_headless(self):
+        self.headless = not self.headless
+
     @init_checker
     def users(self) -> Iterable[User]:
         return self.client.users()

--- a/binsync/common/ui/tables/activiy_table.py
+++ b/binsync/common/ui/tables/activiy_table.py
@@ -75,6 +75,8 @@ class QActivityTable(QTableWidget):
         self.setHorizontalHeaderLabels(self.HEADER)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.horizontalHeader().setHorizontalScrollMode(self.ScrollPerPixel)
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter | Qt.Alignment(Qt.TextWordWrap))
+        self.horizontalHeader().setMinimumWidth(160)
         self.setHorizontalScrollMode(self.ScrollPerPixel)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/binsync/common/ui/tables/ctx_table.py
+++ b/binsync/common/ui/tables/ctx_table.py
@@ -74,7 +74,8 @@ class QCTXTable(QTableWidget):
         self.setHorizontalHeaderLabels(self.HEADER)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.horizontalHeader().setHorizontalScrollMode(self.ScrollPerPixel)
-
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter | Qt.Alignment(Qt.TextWordWrap))
+        self.horizontalHeader().setMinimumWidth(160)
         self.setHorizontalScrollMode(self.ScrollPerPixel)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/binsync/common/ui/tables/functions_table.py
+++ b/binsync/common/ui/tables/functions_table.py
@@ -67,6 +67,8 @@ class QFunctionTable(QTableWidget):
         self.setHorizontalHeaderLabels(self.HEADER)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.horizontalHeader().setHorizontalScrollMode(self.ScrollPerPixel)
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter | Qt.Alignment(Qt.TextWordWrap))
+        self.horizontalHeader().setMinimumWidth(160)
         self.setHorizontalScrollMode(self.ScrollPerPixel)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/binsync/common/ui/tables/globals_table.py
+++ b/binsync/common/ui/tables/globals_table.py
@@ -65,7 +65,8 @@ class QGlobalsTable(QTableWidget):
         self.setHorizontalHeaderLabels(self.HEADER)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.horizontalHeader().setHorizontalScrollMode(self.ScrollPerPixel)
-
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignCenter | Qt.Alignment(Qt.TextWordWrap))
+        self.horizontalHeader().setMinimumWidth(160)
         self.setHorizontalScrollMode(self.ScrollPerPixel)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/plugins/angr_binsync/binsync_plugin.py
+++ b/plugins/angr_binsync/binsync_plugin.py
@@ -41,8 +41,9 @@ class BinsyncPlugin(BasePlugin):
     # BinSync GUI Hooks
     #
 
-    MENU_BUTTONS = ('Configure Binsync...',)
+    MENU_BUTTONS = ('Configure Binsync...', 'Toggle Binsync Panel')
     MENU_CONFIG_ID = 0
+    MENU_TOGGLE_PANEL_ID = 1
 
     def handle_click_menu(self, idx):
         # sanity check on menu selection
@@ -53,11 +54,13 @@ class BinsyncPlugin(BasePlugin):
             return
 
         mapping = {
-            self.MENU_CONFIG_ID: self.open_sync_config_dialog
+            self.MENU_CONFIG_ID: self.open_sync_config_dialog,
+            self.MENU_TOGGLE_PANEL_ID: self.toggle_sync_panel
         }
 
         # call option mapped to each menu pos
         mapping.get(idx)()
+
 
     def open_sync_config_dialog(self):
         if self.workspace.instance.project.am_none:
@@ -66,6 +69,15 @@ class BinsyncPlugin(BasePlugin):
 
         sync_config = SyncConfig(self.controller)
         sync_config.exec_()
+
+    def toggle_sync_panel(self):
+        self.controller.toggle_headless()
+
+        if self.control_panel_view.isVisible():
+            self.control_panel_view.close()
+            return
+
+        self.workspace.add_view(self.control_panel_view)
 
     #
     #   BinSync Decompiler Hooks


### PR DESCRIPTION
Changelog:

1. Fixed resizing mangling the table header names, now the table headers will cut off at word boundaries until absolutely necessary to cut the word off. (it's better I swear)
2. Added the ability to toggle the binsync panel, and toggle it back on when you close it. Closing/hiding the panel stops the UI from updating so will be slightly out of date when toggled back on, but this is currently an acceptable compromise.