### PR TITLE
Persistent Configs

### DIFF
--- a/binsync/common/controller.py
+++ b/binsync/common/controller.py
@@ -228,7 +228,7 @@ class BinSyncController:
 
     def binary_hash(self) -> str:
         """
-        Should return a hex string of the currently loaded binary in the decompiler. For most cases,
+        Returns a hex string of the currently loaded binary in the decompiler. For most cases,
         this will simply be a md5hash of the binary.
 
         @rtype: hex string
@@ -237,13 +237,20 @@ class BinSyncController:
 
     def active_context(self) -> binsync.data.Function:
         """
-        Should return an binsync Function. Currently only functions are supported as current contexts.
+        Returns an binsync Function. Currently only functions are supported as current contexts.
         This function will be called very frequently, so its important that its implementation is fast
         and can be done many times in the decompiler.
         """
-
         raise NotImplementedError
 
+    def binary_path(self) -> Optional[str]:
+        """
+        Returns a string that is the path of the currently loaded binary. If there is no binary loaded
+        then None should be returned.
+
+        @rtype: path-like string (/path/to/binary)
+        """
+        raise NotImplementedError
 
     #
     # Fillers

--- a/plugins/angr_binsync/controller.py
+++ b/plugins/angr_binsync/controller.py
@@ -40,6 +40,12 @@ class AngrBinSyncController(BinSyncController):
 
         return binsync.data.Function(func.addr, header=FunctionHeader(func.name, func.addr))
 
+    def binary_path(self) -> Optional[str]:
+        try:
+            return self._instance.project.loader.main_object.binary
+        except Exception:
+            return None
+
     #
     # Display Fillers
     #

--- a/plugins/binja_binsync/controller.py
+++ b/plugins/binja_binsync/controller.py
@@ -65,6 +65,12 @@ class BinjaBinSyncController(BinSyncController):
 
         return binsync.data.Function(func.start, header=FunctionHeader(func.name, func.start))
 
+    def binary_path(self) -> Optional[str]:
+        try:
+            return self.bv.file.filename
+        except Exception:
+            return None
+
     @init_checker
     @make_ro_state
     def fill_function(self, func_addr, user=None, state=None):

--- a/plugins/ida_binsync/ida_binsync/compat.py
+++ b/plugins/ida_binsync/ida_binsync/compat.py
@@ -401,6 +401,7 @@ class IDAViewCTX:
 def get_screen_ea():
     return idc.get_screen_ea()
 
+
 @execute_read
 def get_function_cursor_at():
     curr_addr = get_screen_ea()
@@ -409,3 +410,11 @@ def get_function_cursor_at():
 
     return ida_func_addr(curr_addr)
 
+
+#
+# Other Utils
+#
+
+@execute_read
+def get_binary_path():
+    return idaapi.get_input_file_path()

--- a/plugins/ida_binsync/ida_binsync/controller.py
+++ b/plugins/ida_binsync/ida_binsync/controller.py
@@ -23,7 +23,7 @@ import threading
 import time
 import datetime
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 from collections import OrderedDict, defaultdict
 
 import idc
@@ -160,6 +160,9 @@ class IDABinSyncController(BinSyncController):
 
         func = binsync.data.Function(func_addr, header=FunctionHeader(compat.get_func_name(func_addr), func_addr))
         self._updated_ctx = func
+
+    def binary_path(self) -> Optional[str]:
+        return compat.get_binary_path()
 
     #
     # IDA DataBase Fillers


### PR DESCRIPTION
Built into the common controller and config_panel, after entering a config once it will be saved onto the filesystem. The config is per-binary based. The config will not persist if the filename and path are not the exact same as when you saved the config. 

Configs are saved as:
`/dir/of/binary/.binary_name.conf.toml`

Finally closes #6 
