### PR TITLE
Refactor imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cp binsync_example_repo/fauxware .
 
 2. Open the fauxware binary in your decompiler, verify it has loaded in the decompiler terminal
 ```
-[Binsync] 2.3.0 loaded
+[BinSync] 2.3.1 loaded
 ```
 
 If it does not show, it means the plugin is not in the plugins folder. 

--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -1,12 +1,15 @@
+VERSION = "2.3.0"
+
 import logging
+
 logging.getLogger("binsync").addHandler(logging.NullHandler())
-from .loggercfg import Loggers
+from binsync.loggercfg import Loggers
+
 loggers = Loggers()
 del Loggers
 del logging
 
-from .state import State, ArtifactType
-from .client import Client, StateContext, ConnectionWarnings
-from .data import *
-
-VERSION = "2.3.0"
+from binsync import common
+from binsync.client import Client, ConnectionWarnings, StateContext
+from binsync.data import *
+from binsync.state import ArtifactType, State

--- a/binsync/__init__.py
+++ b/binsync/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 
 import logging
 

--- a/binsync/client.py
+++ b/binsync/client.py
@@ -1,19 +1,19 @@
-import time
-import threading
-import os
-import subprocess
-import re
 import datetime
 import logging
-from typing import Optional, Iterable
+import os
+import re
+import subprocess
+import threading
+import time
+from typing import Iterable, Optional
 
+import filelock
 import git
 import git.exc
-import filelock
 
-from .data import User, Function, Struct, Patch
-from .state import State
-from .errors import MetadataNotFoundError, ExternalUserCommitError
+from binsync.data import User
+from binsync.errors import ExternalUserCommitError, MetadataNotFoundError
+from binsync.state import State
 
 l = logging.getLogger(__name__)
 BINSYNC_BRANCH_PREFIX = 'binsync'

--- a/binsync/common/__init__.py
+++ b/binsync/common/__init__.py
@@ -1,1 +1,0 @@
-from binsync.common import ui

--- a/binsync/common/__init__.py
+++ b/binsync/common/__init__.py
@@ -1,0 +1,1 @@
+from binsync.common import ui

--- a/binsync/common/controller.py
+++ b/binsync/common/controller.py
@@ -1,14 +1,15 @@
-from functools import wraps
-import threading
-import time
 import datetime
 import logging
-from typing import Optional, Iterable, Dict, List
+import threading
+import time
 from collections import OrderedDict
+from functools import wraps
+from typing import Dict, Iterable, List, Optional
 
 import binsync.data
-from ..client import Client
-from ..data import User, Function, StackVariable, Comment, Struct, GlobalVariable, Enum
+from binsync.client import Client
+from binsync.data import (Comment, Enum, Function, GlobalVariable,
+                          StackVariable, Struct, User)
 
 _l = logging.getLogger(name=__name__)
 

--- a/binsync/common/ui/__init__.py
+++ b/binsync/common/ui/__init__.py
@@ -1,3 +1,0 @@
-from binsync.common.ui import config_dialog
-from binsync.common.ui import control_panel
-from binsync.common.ui import panel_tabs

--- a/binsync/common/ui/__init__.py
+++ b/binsync/common/ui/__init__.py
@@ -1,15 +1,3 @@
-ui_version = "PySide2"
-
-
-def set_ui_version(version):
-    global ui_version
-    valid_version = [
-        "PyQt5",
-        "PySide2",
-        "PySide6"
-    ]
-
-    if version in valid_version:
-        ui_version = version
-    else:
-        raise Exception("Failed to set BinSync UI version")
+from binsync.common.ui import config_dialog
+from binsync.common.ui import control_panel
+from binsync.common.ui import panel_tabs

--- a/binsync/common/ui/config_dialog.py
+++ b/binsync/common/ui/config_dialog.py
@@ -1,25 +1,23 @@
-import traceback
-import os
-from typing import Optional, Dict
-import toml
-import time
 import logging
+import os
+import traceback
+from typing import Optional
 
-from . import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox, \
-        QFileDialog, QCheckBox, QGridLayout
-    from PySide2.QtCore import QDir
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox, \
-        QFileDialog, QCheckBox, QGridLayout
-    from PySide6.QtCore import QDir
-else:
-    from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox, \
-        QFileDialog, QCheckBox, QGridLayout
-    from PyQt5.QtCore import QDir
-
-from ...client import ConnectionWarnings
+import toml
+from binsync.client import ConnectionWarnings
+from binsync.common.ui.qt_objects import (
+    QCheckBox,
+    QDialog,
+    QDir,
+    QFileDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/control_panel.py
+++ b/binsync/common/ui/control_panel.py
@@ -1,24 +1,19 @@
-import datetime
 import logging
 
 import binsync.data
-
-from . import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QVBoxLayout, QGroupBox, QWidget, QLabel, QTabWidget, QTableWidget, QStatusBar
-    from PySide2.QtCore import Signal
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QVBoxLayout, QGroupBox, QWidget, QLabel, QTabWidget, QTableWidget, QStatusBar
-    from PySide6.QtCore import Signal
-else:
-    from PyQt5.QtWidgets import QVBoxLayout, QGroupBox, QWidget, QLabel, QTabWidget, QTableWidget, QStatusBar
-    from PyQt5.QtCore import pyqtSignal as Signal
-
-from .panel_tabs.functions_table import QFunctionTable
-from .panel_tabs.activity_table import QActivityTable
-from .panel_tabs.ctx_table import QCTXTable
-from .panel_tabs.util_panel import QUtilPanel
-from .panel_tabs.globals_table import QGlobalsTable
+from binsync.common.ui.panel_tabs.activity_table import QActivityTable
+from binsync.common.ui.panel_tabs.ctx_table import QCTXTable
+from binsync.common.ui.panel_tabs.functions_table import QFunctionTable
+from binsync.common.ui.panel_tabs.globals_table import QGlobalsTable
+from binsync.common.ui.panel_tabs.util_panel import QUtilPanel
+from binsync.common.ui.qt_objects import (
+    QLabel,
+    QStatusBar,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+    Signal
+)
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/panel_tabs/activity_table.py
+++ b/binsync/common/ui/panel_tabs/activity_table.py
@@ -1,21 +1,18 @@
-from typing import Dict
 import logging
+from typing import Dict
 
-from .. import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PyQt5.QtCore import Qt
-
-from ..utils import QNumericItem, friendly_datetime
-from ...controller import BinSyncController
-from .... import State
-from ....data import Function
+from binsync.common.controller import BinSyncController
+from binsync.common.ui.qt_objects import (
+    QAbstractItemView,
+    QHeaderView,
+    QMenu,
+    Qt,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from binsync.common.ui.utils import QNumericItem, friendly_datetime
+from binsync.data import Function
+from binsync.state import State
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/panel_tabs/ctx_table.py
+++ b/binsync/common/ui/panel_tabs/ctx_table.py
@@ -1,18 +1,15 @@
 import logging
 
-from .. import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PyQt5.QtCore import Qt
-
-from ..utils import QNumericItem, friendly_datetime
-from ...controller import BinSyncController
+from binsync.common.controller import BinSyncController
+from binsync.common.ui.qt_objects import (
+    QAbstractItemView,
+    QHeaderView,
+    QMenu,
+    Qt,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from binsync.common.ui.utils import QNumericItem, friendly_datetime
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/panel_tabs/functions_table.py
+++ b/binsync/common/ui/panel_tabs/functions_table.py
@@ -1,22 +1,18 @@
-from typing import Dict
 import logging
-import importlib
+from typing import Dict
 
-from .. import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PyQt5.QtCore import Qt
-
-from ..utils import QNumericItem, friendly_datetime
-from ...controller import BinSyncController
-from .... import State
-from ....data import Function
+from binsync.common.controller import BinSyncController
+from binsync.common.ui.qt_objects import (
+    QAbstractItemView,
+    QHeaderView,
+    QMenu,
+    Qt,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from binsync.common.ui.utils import QNumericItem, friendly_datetime
+from binsync.data import Function
+from binsync.state import State
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/panel_tabs/globals_table.py
+++ b/binsync/common/ui/panel_tabs/globals_table.py
@@ -1,23 +1,17 @@
-from typing import Dict
 import logging
 import re
 
-from .. import ui_version
-
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QMenu
-    from PyQt5.QtCore import Qt
-
-from ..utils import QNumericItem, friendly_datetime
-from ...controller import BinSyncController
-from .... import State
-from ....data import Struct
+from binsync.common.controller import BinSyncController
+from binsync.common.ui.qt_objects import (
+    QAbstractItemView,
+    QHeaderView,
+    QMenu,
+    Qt,
+    QTableWidget,
+    QTableWidgetItem,
+)
+from binsync.common.ui.utils import QNumericItem, friendly_datetime
+from binsync.state import State
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/panel_tabs/util_panel.py
+++ b/binsync/common/ui/panel_tabs/util_panel.py
@@ -1,18 +1,17 @@
 import logging
 
-from .. import ui_version
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QWidget, QCheckBox, QVBoxLayout, QLabel, QComboBox, QHBoxLayout, QGroupBox, QPushButton
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QWidget, QCheckBox, QVBoxLayout, QLabel, QComboBox, QHBoxLayout, QGroupBox, QPushButton
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QWidget, QCheckBox, QVBoxLayout, QLabel, QComboBox, QHBoxLayout, QGroupBox, QPushButton
-    from PyQt5.QtCore import Qt
-
-from ...controller import BinSyncController, SyncLevel
-
+from binsync.common.controller import BinSyncController, SyncLevel
+from binsync.common.ui.qt_objects import (
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    Qt,
+    QVBoxLayout,
+    QWidget,
+)
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/qt_objects.py
+++ b/binsync/common/ui/qt_objects.py
@@ -49,7 +49,8 @@ elif ui_version == "PySide6":
         QWidget,
     )
 else:
-    from PyQt5.QtCore import QDir, Qt, Signal
+    from PyQt5.QtCore import QDir, Qt
+    from PyQt5.QtCore import pyqtSignal as Signal
     from PyQt5.QtWidgets import (
         QAbstractItemView,
         QCheckBox,

--- a/binsync/common/ui/qt_objects.py
+++ b/binsync/common/ui/qt_objects.py
@@ -1,0 +1,74 @@
+from binsync.common.ui.version import ui_version
+
+if ui_version == "PySide2":
+    from PySide2.QtCore import QDir, Qt, Signal
+    from PySide2.QtWidgets import (
+        QAbstractItemView,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QFileDialog,
+        QGridLayout,
+        QGroupBox,
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QLineEdit,
+        QMenu,
+        QMessageBox,
+        QPushButton,
+        QStatusBar,
+        QTableWidget,
+        QTableWidgetItem,
+        QTabWidget,
+        QVBoxLayout,
+        QWidget,
+    )
+elif ui_version == "PySide6":
+    from PySide6.QtCore import QDir, Qt, Signal
+    from PySide6.QtWidgets import (
+        QAbstractItemView,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QFileDialog,
+        QGridLayout,
+        QGroupBox,
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QLineEdit,
+        QMenu,
+        QMessageBox,
+        QPushButton,
+        QStatusBar,
+        QTableWidget,
+        QTableWidgetItem,
+        QTabWidget,
+        QVBoxLayout,
+        QWidget,
+    )
+else:
+    from PyQt5.QtCore import QDir, Qt, Signal
+    from PyQt5.QtWidgets import (
+        QAbstractItemView,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QFileDialog,
+        QGridLayout,
+        QGroupBox,
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QLineEdit,
+        QMenu,
+        QMessageBox,
+        QPushButton,
+        QStatusBar,
+        QTableWidget,
+        QTableWidgetItem,
+        QTabWidget,
+        QVBoxLayout,
+        QWidget,
+    )

--- a/binsync/common/ui/utils.py
+++ b/binsync/common/ui/utils.py
@@ -1,16 +1,7 @@
-from . import ui_version
-import logging
 import datetime
+import logging
 
-if ui_version == "PySide2":
-    from PySide2.QtWidgets import QTableWidgetItem
-    from PySide2.QtCore import Qt
-elif ui_version == "PySide6":
-    from PySide6.QtWidgets import QTableWidgetItem
-    from PySide6.QtCore import Qt
-else:
-    from PyQt5.QtWidgets import QTableWidgetItem
-    from PyQt5.QtCore import Qt
+from binsync.common.ui.qt_objects import Qt, QTableWidgetItem
 
 l = logging.getLogger(__name__)
 

--- a/binsync/common/ui/version.py
+++ b/binsync/common/ui/version.py
@@ -1,0 +1,15 @@
+ui_version = "PySide2"
+
+
+def set_ui_version(version):
+    global ui_version
+    valid_version = [
+        "PyQt5",
+        "PySide2",
+        "PySide6"
+    ]
+
+    if version in valid_version:
+        ui_version = version
+    else:
+        raise Exception("Failed to set BinSync UI version")

--- a/binsync/data/__init__.py
+++ b/binsync/data/__init__.py
@@ -1,9 +1,9 @@
-from .user import User
-from .artifact import Artifact
-from .func import Function, FunctionHeader, FunctionArgument
-from .comment import Comment
-from .patch import Patch
-from .stack_variable import StackVariable, StackOffsetType
-from .struct import StructMember, Struct
-from .global_variable import GlobalVariable
-from .enum import Enum
+from binsync.data.user import User
+from binsync.data.artifact import Artifact
+from binsync.data.func import Function, FunctionHeader, FunctionArgument
+from binsync.data.comment import Comment
+from binsync.data.patch import Patch
+from binsync.data.stack_variable import StackVariable, StackOffsetType
+from binsync.data.struct import StructMember, Struct
+from binsync.data.global_variable import GlobalVariable
+from binsync.data.enum import Enum

--- a/binsync/data/artifact.py
+++ b/binsync/data/artifact.py
@@ -1,5 +1,6 @@
-import toml
 from typing import Dict
+
+import toml
 
 
 class Artifact:

--- a/binsync/data/comment.py
+++ b/binsync/data/comment.py
@@ -1,5 +1,6 @@
 import toml
-from .artifact import Artifact
+
+from binsync.data.artifact import Artifact
 
 
 class Comment(Artifact):

--- a/binsync/data/enum.py
+++ b/binsync/data/enum.py
@@ -1,7 +1,9 @@
-from .artifact import Artifact
-from typing import Dict
 from collections import OrderedDict
+from typing import Dict
+
 import toml
+
+from binsync.data.artifact import Artifact
 
 
 class Enum(Artifact):

--- a/binsync/data/func.py
+++ b/binsync/data/func.py
@@ -1,9 +1,9 @@
-import toml
 from typing import Dict, Optional
 
-from .artifact import Artifact
-from .stack_variable import StackVariable
+import toml
 
+from binsync.data.artifact import Artifact
+from binsync.data.stack_variable import StackVariable
 
 #
 # Function Header Classes

--- a/binsync/data/global_variable.py
+++ b/binsync/data/global_variable.py
@@ -1,5 +1,6 @@
-from .artifact import Artifact
 import toml
+
+from binsync.data.artifact import Artifact
 
 
 class GlobalVariable(Artifact):

--- a/binsync/data/patch.py
+++ b/binsync/data/patch.py
@@ -1,7 +1,8 @@
 import codecs
+
 import toml
 
-from .artifact import Artifact
+from binsync.data.artifact import Artifact
 
 
 class Patch(Artifact):

--- a/binsync/data/stack_variable.py
+++ b/binsync/data/stack_variable.py
@@ -1,6 +1,6 @@
 import toml
 
-from .artifact import Artifact
+from binsync.data.artifact import Artifact
 
 
 class StackOffsetType:

--- a/binsync/data/struct.py
+++ b/binsync/data/struct.py
@@ -1,7 +1,8 @@
-import toml
-from typing import List, Dict
+from typing import Dict, List
 
-from .artifact import Artifact
+import toml
+
+from binsync.data.artifact import Artifact
 
 
 class StructMember(Artifact):

--- a/binsync/merge.py
+++ b/binsync/merge.py
@@ -1,5 +1,6 @@
-from . import State
 import logging
+
+from binsync.state import State
 
 l = logging.getLogger(__name__)
 

--- a/binsync/state.py
+++ b/binsync/state.py
@@ -1,20 +1,25 @@
-import time
-from typing import List, Dict, Iterable, Union, Optional
-import inspect
 import logging
-
 import os
-from functools import wraps
-from collections import defaultdict
 import pathlib
+import time
+from functools import wraps
+from typing import Dict, Iterable, Optional
 
-from sortedcontainers import SortedDict
-import toml
 import git
+import toml
+from sortedcontainers import SortedDict
 
-from .data import Function, FunctionHeader, Comment, Patch, StackVariable, GlobalVariable, Enum
-from .data.struct import Struct
-from .errors import MetadataNotFoundError
+from binsync.data import (
+    Comment,
+    Enum,
+    Function,
+    FunctionHeader,
+    GlobalVariable,
+    Patch,
+    StackVariable,
+)
+from binsync.data.struct import Struct
+from binsync.errors import MetadataNotFoundError
 
 l = logging.getLogger(__name__)
 

--- a/plugins/angr_binsync/__init__.py
+++ b/plugins/angr_binsync/__init__.py
@@ -1,1 +1,1 @@
-from .binsync_plugin import BinSyncPlugin
+from angrmanagement.plugins.angr_binsync.binsync_plugin import BinSyncPlugin

--- a/plugins/angr_binsync/binsync_plugin.py
+++ b/plugins/angr_binsync/binsync_plugin.py
@@ -1,17 +1,15 @@
+# pylint: disable=wrong-import-position,wrong-import-order
 import logging
 
 import binsync
-from binsync.common.ui import set_ui_version
-
-from ...plugins import BasePlugin
-from ...ui.workspace import Workspace
-from .control_panel_view import ControlPanelView
-from .controller import AngrBinSyncController
+from angrmanagement.plugins import BasePlugin
+from angrmanagement.ui.workspace import Workspace
+from binsync.common.ui.version import set_ui_version
 
 set_ui_version("PySide2")
-# pylint: disable=wrong-import-position,wrong-import-order
 from binsync.common.ui.config_dialog import SyncConfig
-
+from angrmanagement.plugins.angr_binsync.control_panel_view import ControlPanelView
+from angrmanagement.plugins.angr_binsync.controller import AngrBinSyncController
 
 l = logging.getLogger(__name__)
 

--- a/plugins/angr_binsync/control_panel_view.py
+++ b/plugins/angr_binsync/control_panel_view.py
@@ -1,14 +1,9 @@
 import logging
-from PySide2.QtWidgets import QVBoxLayout
 
-from binsync.common.ui import set_ui_version
-
-from .controller import AngrBinSyncController
-from ...ui.views.view import BaseView
-
-set_ui_version("PySide2")
-# pylint: disable=wrong-import-position,wrong-import-order
+from angrmanagement.plugins.angr_binsync.controller import AngrBinSyncController
+from angrmanagement.ui.views.view import BaseView
 from binsync.common.ui.control_panel import ControlPanel
+from binsync.common.ui.qt_objects import QVBoxLayout
 
 
 l = logging.getLogger(__name__)

--- a/plugins/angr_binsync/controller.py
+++ b/plugins/angr_binsync/controller.py
@@ -1,15 +1,18 @@
-import os
 import logging
+import os
 from typing import Optional
 
-from binsync.common.controller import BinSyncController, init_checker, make_ro_state, make_state_with_func
-from binsync.data import StackOffsetType, FunctionHeader
-import binsync
-
-from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
 import angr
-from ...ui.views import CodeView
-
+import binsync
+from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
+from angrmanagement.ui.views import CodeView
+from binsync.common.controller import (
+    BinSyncController,
+    init_checker,
+    make_ro_state,
+    make_state_with_func
+)
+from binsync.data import FunctionHeader, StackOffsetType
 
 l = logging.getLogger(__name__)
 

--- a/plugins/binja_binsync/binja_binsync.py
+++ b/plugins/binja_binsync/binja_binsync.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 import logging
 
 import binsync
-from binsync.common.ui import set_ui_version
+from binsync.common.ui.version import set_ui_version
 set_ui_version("PySide6")
 from binsync.common.ui.config_dialog import SyncConfig
 from binsync.common.ui.control_panel import ControlPanel

--- a/plugins/ida_binsync/ida_binsync/plugin.py
+++ b/plugins/ida_binsync/ida_binsync/plugin.py
@@ -16,7 +16,7 @@ import idc
 import ida_idp
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 
-from binsync.common.ui import set_ui_version
+from binsync.common.ui.version import set_ui_version
 set_ui_version("PyQt5")
 from binsync.common.ui.config_dialog import SyncConfig
 from binsync.common.ui.control_panel import ControlPanel

--- a/plugins/ida_binsync/ida_binsync/plugin.py
+++ b/plugins/ida_binsync/ida_binsync/plugin.py
@@ -113,7 +113,7 @@ class BinsyncPlugin(QObject, idaapi.plugin_t):
     wanted_hotkey = "Ctrl-Shift-B"
 
     def __init__(self, *args, **kwargs):
-        print("[Binsync] {} loaded!".format(VERSION))
+        print("[BinSync] {} loaded!".format(VERSION))
 
         QObject.__init__(self, *args, **kwargs)
         idaapi.plugin_t.__init__(self)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='binsync',
-    version='2.3.0',
+    version='2.3.1',
     packages=packages,
     install_requires=[
         "sortedcontainers",

--- a/tests/test_angr_gui.py
+++ b/tests/test_angr_gui.py
@@ -18,7 +18,7 @@ from angrmanagement.config import Conf
 
 from binsync.common.controller import SyncControlStatus, BINSYNC_RELOAD_TIME
 from binsync.common.ui import utils
-from binsync.common.ui import set_ui_version
+from binsync.common.ui.version import set_ui_version
 set_ui_version("PySide2")
 from binsync.common.ui.config_dialog import SyncConfig
 


### PR DESCRIPTION
This is a refactor of the imports of binsync and then angr_binsync plugins. I began by being more deliberate about importing subpackages in order to make pyinstaller able to find them for the angr managment build. Then I kept scratching some itches until settling on this. Notable changes include:

- Subpackages are usually imported unless there is an explicit reason not to do so.
- The `ui_version` variable and `set_ui_version` function have been pulled out into their own independently importable module.
- All Qt binding switching logic has been centralized into `binsync.common.ui.qt_objects`, and other ui modules just import from there.
- All imports are absolute, no more `from .... import State`. Just `from binsync import State`, it is so much easier to read and I don't even have to think about what directory I'm in.
- Sorted, formatted, removed a bunch of unused imports.

The import path for `set_ui_version` should be the only backwards-incompatible change here. I updated the Binja and IDA plugins accordingly, but I don't really have a way to test them currently.